### PR TITLE
Check for array types

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -276,9 +276,12 @@ export class TypeScriptWorker implements ts.LanguageServiceHost {
 								functionArgument = displayPartsStr.substr(0, displayPartsStr.lastIndexOf(":"));
 							}
 							return `${functionArgument} => {\n    {{${returnValue}}}\n}`
-						} else if (objectFlags & ts.ObjectFlags.Reference) {
-							// Array?
-							return `[]`;
+						} else {
+							const typeString = typeChecker.typeToString(parameterType);
+							const bracketIndex = typeString.indexOf("[]");
+							if (flags & ts.ObjectFlags.Tuple || (bracketIndex !== -1 && bracketIndex === typeString.length - 2)) {
+								return `[]`;
+							}
 						}
 					} else if (flags & ts.TypeFlags.String
 						|| flags & ts.TypeFlags.Number


### PR DESCRIPTION
Fixes the bug where any object type could show up as an array in the completions. Somewhat of a hack but the TS compiler doesn't really expose any way to check if something is an array type.