### PR TITLE
Only show public members of any completion. 

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -198,7 +198,9 @@ export class TypeScriptWorker implements ts.LanguageServiceHost {
 	getCompletionsAtPosition(fileName: string, position: number): Promise<ts.CompletionInfo> {
 		const completions = this._languageService.getCompletionsAtPosition(fileName, position);
 		if (completions && completions.entries)
-			completions.entries = completions.entries.filter(e => ignoredCompletions[e.name] !== e.kind)
+			completions.entries = completions.entries
+				.filter(e => ignoredCompletions[e.name] !== e.kind
+						&& e.name.indexOf('_') != 0)
 		return Promise.as(completions);
 	}
 


### PR DESCRIPTION
Hide items that start with an underscore.

Typescript doesn't yet support a generic way to detect whether a function is deprecated of obsolete. If a function or member property starts with an underscore, we hide it from the intellisense. 

Works well for our use case.